### PR TITLE
ci: simplify on demand system-level tests workflow

### DIFF
--- a/.github/workflows/on_demand_ci_hpc.yaml
+++ b/.github/workflows/on_demand_ci_hpc.yaml
@@ -3,9 +3,6 @@ name: on-demand-system-level-test
 on:
   workflow_dispatch:
     inputs:
-      anemoi_branch:
-        description: Branch for the anemoi repo to be used to deploy the anemoi_tests suite.
-        required: false
       anemoi_datasets_branch:
         description: Branch for anemoi-datasets to be used to build the datasets environment for testing.
         required: false
@@ -31,21 +28,11 @@ jobs:
       - name: Set build options
         id: set_build_options
         run: |
-          build_options=""
+          anemoi_branch="${{ github.ref_name }}"
+          datasets_branch="${{ github.event.inputs.anemoi_datasets_branch }}"
+          training_branch="${{ github.event.inputs.anemoi_training_branch }}"
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            anemoi_branch="${{ github.event.inputs.anemoi_branch }}"
-            datasets_branch="${{ github.event.inputs.anemoi_datasets_branch }}"
-            training_branch="${{ github.event.inputs.anemoi_training_branch }}"
-
-            # Default to ref name if docs branch not specified
-            if [[ -z "$docs_branch" ]]; then
-              anemoi_branch="${{ github.ref_name }}"
-            fi
-
-            build_options="anemoi_branch=$anemoi_branch anemoi_datasets_branch=$datasets_branch anemoi_training_branch=$training_branch"
-          fi
-
+          build_options="anemoi_branch=$anemoi_branch anemoi_datasets_branch=$datasets_branch anemoi_training_branch=$training_branch"
           echo "build_options=$build_options" >> "$GITHUB_OUTPUT"
 
   system_level_test:


### PR DESCRIPTION
### Description
This PR simplifies the on demand system-level tests workflow.
- It removes the `anemoi_branch` option, as the branch of the anemoi repo can be set as the "triggering branch" (and hereby removes a reference do anemoi_docs that we missed)
- It removes some outdated logic (that had remained after separating out the nightly and on-demand workflows for ease of maintenance)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 